### PR TITLE
Fix bug: usage of node-fetch only API

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -19,7 +19,7 @@ exports.requestAndResultsFormatter = async (options) => {
   const requestUrl = options.url;
 
   const response = await ky.get(requestUrl, options);
-  let formatBody = await response.buffer();
+  let formatBody = await response.text();
 
   if (response && response.status && (response.status.toString().substring(0, 1) === '4' || response.status.toString().substring(0, 1) === '5')) {
     throw new Error('Server has returned a 400/500 error code');


### PR DESCRIPTION
From node-fetch/README.md:

If you prefer to cache binary data in full, use buffer(). (NOTE: buffer() is a `node-fetch` only API)