### PR TITLE
Replace Buffer.from with Uint8Array

### DIFF
--- a/dist/lib/fallback.js
+++ b/dist/lib/fallback.js
@@ -204,7 +204,9 @@ function fallback(ogObject, options, $, body) {
         ogObject.charset = charsetRegEx.test(content) ? charsetRegEx.exec(content)[1] : 'UTF-8';
     }
     else if (body) {
-        ogObject.charset = chardet_1.default.detect(Buffer.from(body)) || '';
+        const encoder = new TextEncoder();
+        const uint8Array = encoder.encode(body);
+        ogObject.charset = chardet_1.default.detect(uint8Array) || '';
     }
     return ogObject;
 }

--- a/lib/fallback.ts
+++ b/lib/fallback.ts
@@ -180,7 +180,9 @@ export function fallback(ogObject: OgObjectInteral, options: OpenGraphScraperOpt
     const charsetRegEx = /charset=([^()<>@,;:"/[\]?.=\s]*)/i;
     ogObject.charset = charsetRegEx.test(content) ? charsetRegEx.exec(content)[1] : 'UTF-8';
   } else if (body) {
-    ogObject.charset = chardet.detect(Buffer.from(body)) || '';
+    const encoder = new TextEncoder();
+    const uint8Array = encoder.encode(body);
+    ogObject.charset = chardet.detect(uint8Array) || '';
   }
 
   return ogObject;


### PR DESCRIPTION
Since this package is not meant to be used with Node.js, the usage of Buffer was an issue.

I've replaced it with TextEncoder.

This makes it possible to use this package with Cloudflare workers (which is based on web platform APIs)